### PR TITLE
Add commons controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.happiercows.config;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -9,6 +10,7 @@ import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -22,10 +24,15 @@ import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
 import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import lombok.extern.slf4j.Slf4j;
+import springfox.documentation.swagger.web.ApiKeyVehicle;
+import springfox.documentation.swagger.web.SecurityConfiguration;
 
 @Configuration
 @EnableWebSecurity
@@ -41,20 +48,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {
-    http.authorizeRequests(authorize -> authorize
-          .anyRequest().permitAll()
-        )
-        .exceptionHandling(handlingConfigurer -> handlingConfigurer
-          .authenticationEntryPoint(new Http403ForbiddenEntryPoint())
-        )
-        .oauth2Login(oauth2 -> oauth2.userInfoEndpoint(userInfo -> userInfo.userAuthoritiesMapper(this.userAuthoritiesMapper())))
-        .csrf(csrf -> csrf
-            .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-        )
-        .logout(logout -> logout
-            .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
-            .logoutSuccessUrl("/")
-        );
+    http.authorizeRequests(authorize -> authorize.anyRequest().permitAll())
+        .exceptionHandling(
+            handlingConfigurer -> handlingConfigurer.authenticationEntryPoint(new Http403ForbiddenEntryPoint()))
+        .oauth2Login(
+            oauth2 -> oauth2.userInfoEndpoint(userInfo -> userInfo.userAuthoritiesMapper(this.userAuthoritiesMapper())))
+        // .csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()))
+        .csrf().disable()
+        .logout(logout -> logout.logoutRequestMatcher(new AntPathRequestMatcher("/logout")).logoutSuccessUrl("/"));
     ;
   }
 
@@ -90,6 +91,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
       return mappedAuthorities;
     };
   }
+
   public boolean isAdmin(String email) {
     if (adminEmails.contains(email)) {
       return true;

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CSRFController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CSRFController.java
@@ -1,0 +1,22 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Controller
+@Slf4j
+public class CSRFController {
+    @RequestMapping(value = "/csrf", method = RequestMethod.GET, produces = "application/json;charset=UTF-8")
+    public ResponseEntity<CsrfToken> getToken(final HttpServletRequest request) {
+        log.info("*****CSRF******");
+        return ResponseEntity.ok().body(new HttpSessionCsrfTokenRepository().generateToken(request));
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -10,13 +10,17 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Api(description = "Commons")
 @RequestMapping("/api/commons")
 @RestController
@@ -37,11 +41,15 @@ public class CommonsController extends ApiController {
     }
 
     @ApiOperation(value = "Create a new commons")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PostMapping(value = "", produces = "application/json")
-    public ResponseEntity<String> createCourse(@RequestBody Commons commons) throws JsonProcessingException {
-        Commons savedCommons = commonsRepository.save(commons);
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping(value = "/new", produces = "application/json")
+    public ResponseEntity<String> createCommons(@ApiParam("name of commons") @RequestParam String name)
+            throws JsonProcessingException {
+        log.info("name={}", name);
+        Commons c = Commons.builder().name(name).build();
+        Commons savedCommons = commonsRepository.save(c);
         String body = mapper.writeValueAsString(savedCommons);
+        log.info("body={}", body);
         return ResponseEntity.ok().body(body);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -1,0 +1,47 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@Api(description = "Commons")
+@RequestMapping("/api/commons")
+@RestController
+public class CommonsController extends ApiController {
+    @Autowired
+    CommonsRepository commonsRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @ApiOperation(value = "Get a list of all commons")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public ResponseEntity<String> getCommons() throws JsonProcessingException {
+        Iterable<Commons> users = commonsRepository.findAll();
+        String body = mapper.writeValueAsString(users);
+        return ResponseEntity.ok().body(body);
+    }
+
+    @ApiOperation(value = "Create a new commons")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping(value = "", produces = "application/json")
+    public ResponseEntity<String> createCourse(@RequestBody Commons commons) throws JsonProcessingException {
+        Commons savedCommons = commonsRepository.save(commons);
+        String body = mapper.writeValueAsString(savedCommons);
+        return ResponseEntity.ok().body(body);
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -1,6 +1,5 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
-import javax.transaction.Transactional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -8,10 +7,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,7 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 @Api(description = "Commons")
 @RequestMapping("/api/commons")
 @RestController
-@Transactional
 public class CommonsController extends ApiController {
     @Autowired
     CommonsRepository commonsRepository;

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -1,11 +1,14 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
+import javax.transaction.Transactional;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 @Api(description = "Commons")
 @RequestMapping("/api/commons")
 @RestController
+@Transactional
 public class CommonsController extends ApiController {
     @Autowired
     CommonsRepository commonsRepository;
@@ -35,13 +39,14 @@ public class CommonsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("")
     public ResponseEntity<String> getCommons() throws JsonProcessingException {
+        log.info("getCommons()...");
         Iterable<Commons> users = commonsRepository.findAll();
         String body = mapper.writeValueAsString(users);
         return ResponseEntity.ok().body(body);
     }
 
     @ApiOperation(value = "Create a new commons")
-    @PreAuthorize("hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping(value = "/new", produces = "application/json")
     public ResponseEntity<String> createCommons(@ApiParam("name of commons") @RequestParam String name)
             throws JsonProcessingException {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
@@ -1,6 +1,5 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
-import javax.transaction.Transactional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -20,7 +19,6 @@ import io.swagger.annotations.ApiOperation;
 @Api(description="User information (admin only)")
 @RequestMapping("/api/admin/users")
 @RestController
-@Transactional
 public class UsersController extends ApiController {
     @Autowired
     UserRepository userRepository;

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
+import javax.transaction.Transactional;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -18,6 +20,7 @@ import io.swagger.annotations.ApiOperation;
 @Api(description="User information (admin only)")
 @RequestMapping("/api/admin/users")
 @RestController
+@Transactional
 public class UsersController extends ApiController {
     @Autowired
     UserRepository userRepository;

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -21,7 +21,7 @@ public class Commons {
   private long id;  
   private String name;
 
-  @ManyToMany(cascade = CascadeType.ALL)
+  @ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
   @JoinTable(name = "user_commons", 
     joinColumns = @JoinColumn(name = "user_id", referencedColumnName = "id"), 
     inverseJoinColumns = @JoinColumn(name = "commons_id", referencedColumnName = "id"))

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -37,7 +38,7 @@ public class User {
   private String hostedDomain;
   private boolean admin;
 
-  @ManyToMany(cascade = CascadeType.ALL)
+  @ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
   @JoinTable(name = "user_commons", 
     joinColumns = @JoinColumn(name = "commons_id", referencedColumnName = "id"), 
     inverseJoinColumns = @JoinColumn(name = "user_id", referencedColumnName = "id"))

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/CurrentUserServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/CurrentUserServiceImpl.java
@@ -7,8 +7,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-import javax.transaction.Transactional;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -26,7 +24,6 @@ import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 
 @Slf4j
 @Service("currentUser")
-@Transactional
 public class CurrentUserServiceImpl extends CurrentUserService {
   @Autowired
   private UserRepository userRepository;


### PR DESCRIPTION
This PR contains a first attempt at a controller for the Commons.

One issue is that the POST request doesn't work unless you disable CSRF protection, which seems like a bad idea for the long term. I suggest, however, that rather than letting that be a blocker, we temporarily disable CSRF protection so that the team can make progress, while we tackle that as a separate concern.

Let's discuss as a team.

The intent is to add  these endpoints:

* GET `/api/commons` : list all commons
* POST `/api/commons` : add a new commons
* DELETE `/api/commons/{id}` : delete a commons

Another issue is that the form for a commons on the current app looks like this:

![image](https://user-images.githubusercontent.com/1119017/117341119-98dd6a00-ae56-11eb-816b-a8a53c22f284.png)


But of the fields in this form, the database table for a Commons only has a place to store the commons name.   This raises the question: where are the other fields? (Cow price, milk price, start date, end date?)