### PR TITLE
docs: remove outdated TEST_PROPERTIES step

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -22,8 +22,6 @@ jobs:
         java-version: '11'
         distribution: 'adopt'
     - name: Build with Maven
-      env:
-        TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
       run: mvn -B test jacoco:report -Dskip.npm
     - name: Upload to Codecov
       env:

--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ This rewrite uses the new tech stack being developed for [CMPSC 156](https://ucs
 Storybook is here:
 * Production: <https://happycows.github.io/HappierCows-docs/>
 * QA: <https://happycows.github.io/HappierCows-docs-qa/>
-# Test setup
-
-For testing, you need to set a repository secret `TEST_PROPERTIES` to be the contents of `.env.SAMPLE`.   It is not necessary to have
-valid values for each of the environment variables, but if they are undefined, the tests will fail.
 
 # Setup before running application
 


### PR DESCRIPTION
This PR removes the `TEST_PROPERTIES` instructions from the README and from CI. The `TEST_PROPERTIES` has never been necessary for this repo as it is not even read from in the pom.xml. Secrets necessary for any environment should be defined as separate environment variables.